### PR TITLE
Run tests in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Build source
         run: spago build --no-install --purs-args '--censor-lib --strict'
 
-#      - name: Run tests
-#        run: spago test --no-install
+      - name: Run tests
+        run: spago build --no-install --then "node -e \"import { main } from './output/Test.Main/index.js'; main();\" --input-type=module"
 
       - name: Verify Bower & Pulp
         run: |


### PR DESCRIPTION
**Description of the change**

I noticed that the _Run tests_ step was commented out (which I assume means that Spago doesn't support ES Modules yet?)

In case we'd like to reinstate the testing step in the short term, I've found a temporary workaround...