### PR TITLE
Update `.gitignore` to contrib standard.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,9 @@
-/node_modules/
-/src/.webpack.js
+.*
+!.gitignore
+!.github
+!.editorconfig
+!.tidyrc.json
 
-.psc-ide-port
-.psc-package
-
-/bower_components/
-/.pulp-cache/
-/output/
-/.psci*
-
-/documentation/bower_components/
-/documentation/.pulp-cache/
-/documentation/output/
-/documentation/.psci*
-
-/documentation/html/test.js
-./spago
-.purs-repl
+output
 generated-docs
+bower_components


### PR DESCRIPTION
I sourced this from the [governance](https://github.com/purescript-contrib/governance/blob/main/updater/templates/base/.gitignore) repository per @thomashoneyman's suggestion. I double-checked it in my environment, and (not surprisingly) it seems to work fine for this project.